### PR TITLE
Added ListSeriesEvent and extracted ListSeriesHandler

### DIFF
--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/InfluxObject.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/InfluxObject.java
@@ -9,18 +9,18 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @SuppressWarnings("unused")
 @XmlRootElement
-class InfluxObject {
+public class InfluxObject {
 
-    InfluxObject() {
+    public InfluxObject() {
     }
 
-    InfluxObject(String name) {
+    public InfluxObject(String name) {
         this.name = name;
     }
 
-    String name;
-    List<String> columns;
-    List<List<?>> points;
+    public String name;
+    public List<String> columns;
+    public List<List<?>> points;
 
     public String getName() {
         return name;

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/query/ListSeriesEvent.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/query/ListSeriesEvent.java
@@ -1,0 +1,24 @@
+package org.rhq.metrics.restServlet.influx.query;
+
+import javax.ws.rs.container.AsyncResponse;
+
+/**
+ * @author Thomas Segismont
+ */
+public class ListSeriesEvent {
+    private final AsyncResponse asyncResponse;
+    private final String tenantId;
+
+    public ListSeriesEvent(AsyncResponse asyncResponse, String tenantId) {
+        this.asyncResponse = asyncResponse;
+        this.tenantId = tenantId;
+    }
+
+    public AsyncResponse getAsyncResponse() {
+        return asyncResponse;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/query/ListSeriesHandler.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/query/ListSeriesHandler.java
@@ -1,0 +1,64 @@
+package org.rhq.metrics.restServlet.influx.query;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedExecutorService;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import org.rhq.metrics.core.Metric;
+import org.rhq.metrics.core.MetricType;
+import org.rhq.metrics.core.MetricsService;
+import org.rhq.metrics.restServlet.influx.InfluxObject;
+
+/**
+ * @author Thomas Segismont
+ */
+@ApplicationScoped
+public class ListSeriesHandler {
+
+    @Inject
+    private MetricsService metricsService;
+
+    @Resource
+    private ManagedExecutorService executor;
+
+    public void listSeries(@Observes ListSeriesEvent listSeriesEvent) {
+        ListenableFuture<List<Metric>> future = metricsService.findMetrics(listSeriesEvent.getTenantId(),
+            MetricType.NUMERIC);
+        Futures.addCallback(future, new FutureCallback<List<Metric>>() {
+            @Override
+            public void onSuccess(List<Metric> result) {
+                List<InfluxObject> objects = new ArrayList<>(result.size());
+
+                for (Metric metric : result) {
+                    InfluxObject obj = new InfluxObject(metric.getId().getName());
+                    obj.columns = new ArrayList<>(2);
+                    obj.columns.add("time");
+                    obj.columns.add("sequence_number");
+                    obj.columns.add("val");
+                    obj.points = new ArrayList<>(1);
+                    objects.add(obj);
+                }
+
+                Response.ResponseBuilder builder = Response.ok(objects);
+
+                listSeriesEvent.getAsyncResponse().resume(builder.build());
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                listSeriesEvent.getAsyncResponse().resume(t);
+            }
+        }, executor);
+    }
+
+}


### PR DESCRIPTION
This is not ready to be merged, I just pushed an example in order to gather feedback.

This is an attempt to make REST handlers classes shorter. CDI events decouples the JAX-RS annotated bean from the actual handling code (and vice versa).

We could have for example:
```java
@Observes @NewData NumericMetricEvent
```

Then both InfluxHandler and vanilla handler could fire a ```@NewData NumericMetricEvent```

WDYT?