### PR TITLE
Config management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2014 Red Hat, Inc.
+  ~ Copyright 2015 Red Hat, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -153,6 +153,13 @@
         <artifactId>antlr4-runtime</artifactId>
         <version>${antlr.version}</version>
       </dependency>
+      <!-- Tests dependencies -->
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.11</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
@@ -160,9 +167,9 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>1.10.19</version>
         <scope>test</scope>
       </dependency>
       <!-- TestNG is not RHQ-Metrics main testing framework -->
@@ -174,6 +181,7 @@
         <version>${testng.version}</version>
         <scope>test</scope>
       </dependency>
+      <!-- Other -->
       <dependency>
         <groupId>org.rhq.checkstyle</groupId>
         <artifactId>rhq-checkstyle-config</artifactId>

--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2014 Red Hat, Inc.
+  ~ Copyright 2015 Red Hat, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -98,7 +98,10 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/MetricsServiceProducer.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/MetricsServiceProducer.java
@@ -15,11 +15,16 @@
  */
 package org.rhq.metrics.restServlet;
 
+import static org.rhq.metrics.restServlet.config.ConfigurationKey.BACKEND;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Produces;
+import javax.inject.Inject;
 
 import org.rhq.metrics.RHQMetrics;
 import org.rhq.metrics.core.MetricsService;
+import org.rhq.metrics.restServlet.config.Configurable;
+import org.rhq.metrics.restServlet.config.ConfigurationProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,13 +35,16 @@ import org.slf4j.LoggerFactory;
 public class MetricsServiceProducer {
     private static final Logger LOG = LoggerFactory.getLogger(MetricsServiceProducer.class);
 
+    @Inject
+    @Configurable
+    @ConfigurationProperty(BACKEND)
+    private String backend;
+
     private MetricsService metricsService;
 
     @Produces
     public MetricsService getMetricsService() {
         if (metricsService == null) {
-            String backend = System.getProperty("rhq-metrics.backend");
-
             RHQMetrics.Builder metricsServiceBuilder = new RHQMetrics.Builder();
 
             if (backend != null) {

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/Configurable.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/Configurable.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.config;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.inject.Qualifier;
+
+/**
+ * Qualifier for an injected field or parameter which value should be fetched from configuration. For example:
+ * <pre>
+ *     &#064;Configurable
+ *     &#064;ConfigurationProperty(ConfigurationKey.BACKEND)
+ *     &#064;Inject
+ *     String backendType;
+ * </pre>
+ * Configuration is a set of key/value pairs (configuration properties) defined by the following sources, in order of
+ * precedence:
+ * <ul>
+ *     <li>system properties (-Dkey=value)</li>
+ *     <li>external {@link java.util.Properties} file, which path is defined by the <em>metrics.conf</em> system
+ *     property; by default, <em>&lt;user.home&gt;/.metrics.conf</em> is used</li>
+ *     <li>internal {@link java.util.Properties} file (<em>META-INF/metrics.conf</em>)</li>
+ * </ul>
+ * Any field or parameter annotated with {@link Configurable} must also be annotated with {@link ConfigurationProperty}.
+ * The value of the latter specifies the configuration property key. Otherwise the configuration producer method will
+ * throw an instance of {@link java.lang.IllegalArgumentException}. In most cases, a configuration property should at
+ * least be defined in the internal properties file, in order to provide a default value.<br/>
+ * <br/>
+ * Configuration values may be modified at runtime (through JMX). When a bean can/should adapt to such changes, the
+ * injected field or parameter type can be wrapped with {@link javax.enterprise.inject.Instance}. The configuration
+ * value will be fetched on each call to {@link javax.enterprise.inject.Instance#get()}.
+ *
+ * @author Thomas Segismont
+ * @see ConfigurationProperty
+ * @see ConfigurableProducer
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD, PARAMETER })
+@Documented
+public @interface Configurable {
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurableProducer.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurableProducer.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.config;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Produces;
+import javax.enterprise.inject.spi.InjectionPoint;
+
+/**
+ * @author Thomas Segismont
+ * @see Configurable
+ */
+@ApplicationScoped
+public class ConfigurableProducer {
+    // Empty if external configuration file should be ignored
+    private Optional<File> configurationFile;
+    // Value needs to be Optional as ConcurrentHashMap does not allow null values
+    private ConcurrentMap<String, Optional<String>> effectiveConfiguration;
+    private CopyOnWriteArraySet<String> readSystemProperties;
+
+    @PostConstruct
+    void init() {
+        evalConfigurationFile();
+        Map<String, String> defaultProperties = loadDefaultProperties();
+        effectiveConfiguration = new ConcurrentHashMap<>(defaultProperties.size());
+        defaultProperties.forEach((k, v) -> effectiveConfiguration.put(k, Optional.ofNullable(v)));
+        configurationFile.ifPresent(file -> {
+            Map<String, String> configurationFileProperties = loadConfigurationFileProperties(file);
+            configurationFileProperties.forEach((k, v) -> effectiveConfiguration.put(k, Optional.ofNullable(v)));
+        });
+        readSystemProperties = new CopyOnWriteArraySet<>();
+    }
+
+    @Produces
+    @Configurable
+    String getConfigurationPropertyAsString(InjectionPoint injectionPoint) {
+        return lookupConfigurationProperty(injectionPoint);
+    }
+
+    private String lookupConfigurationProperty(InjectionPoint injectionPoint) {
+        String propertyName = getConfigurationPropertyName(injectionPoint);
+        if (!readSystemProperties.contains(propertyName)) {
+            String sysprop = System.getProperty(propertyName);
+            if (sysprop != null) {
+                effectiveConfiguration.put(propertyName, Optional.of(sysprop));
+            }
+            readSystemProperties.add(propertyName);
+        }
+        return effectiveConfiguration.get(propertyName).orElse(null);
+    }
+
+    private String getConfigurationPropertyName(InjectionPoint injectionPoint) {
+        ConfigurationProperty annotation = injectionPoint.getAnnotated().getAnnotation(ConfigurationProperty.class);
+        return annotation.value().getExternalForm();
+    }
+
+    private void evalConfigurationFile() {
+        String configurationFilePath = System.getProperty("metrics.conf");
+        if (configurationFilePath != null) {
+            File file = new File(configurationFilePath);
+            checkExplicitConfigurationFile(file);
+            configurationFile = Optional.of(file);
+        } else {
+            File file = new File(System.getProperty("user.home"), ".metrics.conf");
+            if (!file.exists()) {
+                configurationFile = Optional.empty();
+            } else {
+                checkConfigurationFile(file);
+                configurationFile = Optional.of(file);
+            }
+        }
+    }
+
+    private void checkExplicitConfigurationFile(File file) {
+        if (!file.exists()) {
+            throw new IllegalArgumentException(file + " does not exist");
+        }
+        checkConfigurationFile(file);
+    }
+
+    private void checkConfigurationFile(File file) {
+        if (!file.isFile()) {
+            throw new IllegalArgumentException(file + " is not a regular file");
+        }
+        if (!file.canRead()) {
+            throw new IllegalArgumentException(file + " is not readable");
+        }
+    }
+
+    private Map<String, String> loadConfigurationFileProperties(File file) {
+        try (FileInputStream input = new FileInputStream(file)) {
+            return propertiesToMap(input);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, String> loadDefaultProperties() {
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream("META-INF/metrics.conf")) {
+            return propertiesToMap(input);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, String> propertiesToMap(InputStream input) throws IOException {
+        Properties properties = new Properties();
+        properties.load(input);
+        Map<String, String> map = new HashMap<>(properties.size());
+        properties.stringPropertyNames().forEach(name -> map.put(name, properties.getProperty(name)));
+        return map;
+    }
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurableProducer.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurableProducer.java
@@ -44,9 +44,10 @@ import org.rhq.metrics.restServlet.management.MBeanRegistrar;
  */
 @ApplicationScoped
 public class ConfigurableProducer implements ConfigurationManagement {
+    static final String METRICS_CONF = "metrics.conf";
 
     @Inject
-    private MBeanRegistrar mBeanRegistrar;
+    MBeanRegistrar mBeanRegistrar;
 
     // Empty if external configuration file should be ignored
     private Optional<File> configurationFile;
@@ -77,6 +78,11 @@ public class ConfigurableProducer implements ConfigurationManagement {
     @Configurable
     String getConfigurationPropertyAsString(InjectionPoint injectionPoint) {
         ConfigurationProperty configProp = injectionPoint.getAnnotated().getAnnotation(ConfigurationProperty.class);
+        if (configProp == null) {
+            String message = "Any field or parameter annotated with @Configurable "
+                + "must also be annotated with @ConfigurationProperty";
+            throw new IllegalArgumentException(message);
+        }
         String propertyName = configProp.value().getExternalForm();
         return lookupConfigurationProperty(propertyName);
     }
@@ -93,7 +99,7 @@ public class ConfigurableProducer implements ConfigurationManagement {
     }
 
     private void evalConfigurationFile() {
-        String configurationFilePath = System.getProperty("metrics.conf");
+        String configurationFilePath = System.getProperty(METRICS_CONF);
         if (configurationFilePath != null) {
             File file = new File(configurationFilePath);
             checkExplicitConfigurationFile(file);

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurationKey.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurationKey.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.config;
+
+/**
+ * Application configuration keys.
+ *
+ * @author Thomas Segismont
+ * @see Configurable
+ */
+public enum ConfigurationKey {
+    /**
+     * Storage type. The value may be one of:
+     * <ul>
+     *     <li><em>mem</em> for memory</li>
+     *     <li><em>cass</em> for Cassandra</li>
+     * </ul>
+     * Memory backend will be used whenever the value is not <em>cass</em>.
+     */
+    BACKEND("rhq-metrics.backend");
+
+    private String externalForm;
+
+    ConfigurationKey(String externalForm) {
+        this.externalForm = externalForm;
+    }
+
+    public String getExternalForm() {
+        return externalForm;
+    }
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurationManagement.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurationManagement.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.config;
+
+import javax.management.MBeanOperationInfo;
+import javax.management.MXBean;
+
+import org.rhq.metrics.restServlet.management.Description;
+import org.rhq.metrics.restServlet.management.Impact;
+import org.rhq.metrics.restServlet.management.KeyProperty;
+import org.rhq.metrics.restServlet.management.MBean;
+import org.rhq.metrics.restServlet.management.OperationParamName;
+
+/**
+ * @author Thomas Segismont
+ */
+@MBean(keyProperties = @KeyProperty(key = "type", value = "Configuration"))
+@Description("Configuration management")
+@MXBean
+public interface ConfigurationManagement {
+    @Description("Lists the configuration property keys. Some properties may be missing if they were not loaded yet.")
+    String[] getConfigurationPropertyKeys();
+
+    @Impact(MBeanOperationInfo.INFO)
+    @Description("Get the value of a configuration property")
+    String getConfigurationProperty(
+        @Description("External form of the configuration property key") @OperationParamName("key") String key);
+
+    @Impact(MBeanOperationInfo.ACTION)
+    @Description("Set the value of a configuration property")
+    void updateConfigurationProperty(@OperationParamName("key") String key, @OperationParamName("value") String value);
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurationProperty.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/config/ConfigurationProperty.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.config;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the {@link ConfigurationKey} for {@link Configurable} injection points.
+ *
+ * @author Thomas Segismont
+ * @see Configurable
+ */
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD, PARAMETER })
+@Documented
+public @interface ConfigurationProperty {
+    ConfigurationKey value();
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/Description.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/Description.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Provides a management bean, attribute, operation or parameter description. On a management interface, it may be used
+ * to annotate:
+ * <ul>
+ *     <li>the type (MBean description)</li>
+ *     <li>a getter method (attribute description)</li>
+ *     <li>a setter method (write-only attribute description)</li>
+ *     <li>a method (operation description)</li>
+ *     <li>a method parameter (operation parameter description)</li>
+ * </ul>
+ *
+ * @author Thomas Segismont
+ * @see org.rhq.metrics.restServlet.management.MBean
+ */
+@Retention(value = RUNTIME)
+@Target({ TYPE, METHOD, PARAMETER })
+@Documented
+public @interface Description {
+    /**
+     * @return the bean, attribute, operation or parameter description
+     */
+    String value();
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/Impact.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/Impact.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a management interface operation to describe the impact of invoking it.
+ *
+ * @author Thomas Segismont
+ * @see org.rhq.metrics.restServlet.management.MBean
+ */
+@Retention(RUNTIME)
+@Target({ METHOD })
+@Documented
+public @interface Impact {
+    /**
+     * @return one of {@link javax.management.MBeanOperationInfo#ACTION},
+     * {@link javax.management.MBeanOperationInfo#INFO} or {@link javax.management.MBeanOperationInfo#ACTION_INFO}
+     */
+    int value();
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/InterfaceInfo.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/InterfaceInfo.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.util.stream.Collectors.toMap;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.util.Arrays;
+import java.util.Hashtable;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.management.MXBean;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+/**
+ * @author Thomas Segismont
+ */
+class InterfaceInfo {
+    private final Class<Object> interfaceClass;
+    private final ObjectName objectName;
+    private final String description;
+    private final boolean mxBean;
+    private final Set<PropertyInfo> propertyInfos;
+    private final Set<MethodInfo> methodInfos;
+
+    private InterfaceInfo(Class<Object> interfaceClass, ObjectName objectName, String description, boolean mxBean,
+        Set<PropertyInfo> propertyInfos, Set<MethodInfo> methodInfos) {
+        Objects.requireNonNull(interfaceClass);
+        Objects.requireNonNull(objectName);
+        Objects.requireNonNull(description);
+        Objects.requireNonNull(propertyInfos);
+        Objects.requireNonNull(methodInfos);
+        this.interfaceClass = interfaceClass;
+        this.objectName = objectName;
+        this.description = description;
+        this.mxBean = mxBean;
+        this.propertyInfos = propertyInfos;
+        this.methodInfos = methodInfos;
+    }
+
+    static InterfaceInfo newIntance(Class<Object> managementInterface) {
+        MBean mBean = managementInterface.getAnnotation(MBean.class);
+        Description description = managementInterface.getAnnotation(Description.class);
+        ObjectName objectName;
+        try {
+            Map<String, String> keyProperties = Arrays.stream(mBean.keyProperties())
+                    .collect(toMap(KeyProperty::key, KeyProperty::value));
+            objectName = new ObjectName(mBean.domain(), new Hashtable<>(keyProperties));
+        } catch (MalformedObjectNameException e) {
+            throw new RuntimeException(e);
+        }
+        boolean mxBean = managementInterface.getAnnotation(MXBean.class) != null;
+        BeanInfo javaBean;
+        try {
+            javaBean = Introspector.getBeanInfo(managementInterface);
+        } catch (IntrospectionException e) {
+            throw new RuntimeException(e);
+        }
+        Set<PropertyInfo> propertyInfos = PropertyInfo.from(javaBean.getPropertyDescriptors());
+        Set<MethodInfo> methodInfos = MethodInfo.from(javaBean.getMethodDescriptors());
+        return new InterfaceInfo(managementInterface, objectName, description != null ? description.value() : "",
+            mxBean, propertyInfos, methodInfos);
+    }
+
+    public Class<Object> getInterfaceClass() {
+        return interfaceClass;
+    }
+
+    public ObjectName getObjectName() {
+        return objectName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isMxBean() {
+        return mxBean;
+    }
+
+    public Set<PropertyInfo> getPropertyInfos() {
+        return propertyInfos;
+    }
+
+    public Set<MethodInfo> getMethodInfos() {
+        return methodInfos;
+    }
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/KeyProperty.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/KeyProperty.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a key/value pair in an MBean object name. For example, in
+ * <em>java.lang:type=GarbageCollector,name=ConcurrentMarkSweep</em>, the key properties are:
+ * <ul>
+ *     <li><em>type=GarbageCollector</em></li>
+ *     <li><em>name=ConcurrentMarkSweep</em></li>
+ * </ul>
+ *
+ * @author Thomas Segismont
+ * @see org.rhq.metrics.restServlet.management.MBean
+ */
+@Retention(value = RUNTIME)
+@Target(value = TYPE)
+@Documented
+public @interface KeyProperty {
+    /**
+     * @return the key part of this property
+     */
+    String key();
+
+    /**
+     * @return the value part of this property
+     */
+    String value();
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MBean.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MBean.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotates a <a href="http://docs.oracle.com/javase/tutorial/jmx/mbeans/standard.html">standard MBean</a> or
+ * <a href="http://docs.oracle.com/javase/tutorial/jmx/mbeans/mxbeans.html">MXBean</a> interface.
+ *
+ * @author Thomas Segismont
+ * @see org.rhq.metrics.restServlet.management.KeyProperty
+ * @see org.rhq.metrics.restServlet.management.Description
+ * @see org.rhq.metrics.restServlet.management.Impact
+ * @see org.rhq.metrics.restServlet.management.OperationParamName
+ */
+@Retention(value = RUNTIME)
+@Target(value = TYPE)
+@Documented
+public @interface MBean {
+    String DEFAULT_DOMAIN = "org.rhq.metrics";
+
+    /**
+     * @return the MBean domain, defaults to {@link #DEFAULT_DOMAIN}
+     */
+    String domain() default DEFAULT_DOMAIN;
+
+    /**
+     * @return the key properties in the object name
+     * @see org.rhq.metrics.restServlet.management.KeyProperty
+     */
+    KeyProperty[] keyProperties();
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MBeanRegistrar.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MBeanRegistrar.java
@@ -32,7 +32,7 @@ import javax.management.ObjectName;
 @ApplicationScoped
 public class MBeanRegistrar {
 
-    private MBeanServer mBeanServer;
+    MBeanServer mBeanServer;
 
     @PostConstruct
     void init() {

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MBeanRegistrar.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MBeanRegistrar.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+/**
+ * Registers an object as a JMX bean.
+ * @author Thomas Segismont
+ */
+@ApplicationScoped
+public class MBeanRegistrar {
+
+    private MBeanServer mBeanServer;
+
+    @PostConstruct
+    void init() {
+        mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    }
+
+    /**
+     * Registers an object as a JMX Bean.
+     * <p>
+     *     The object must implement exactly one <em>direct</em> interface annotated with
+     *     {@link org.rhq.metrics.restServlet.management.MBean}. This interface will be the management interface exposed
+     *     by the object.
+     * </p>
+     * <strong>The caller must take care of the object unregistration.</strong>
+     *
+     * @param managedBean the object to register as a JMX bean
+     * @see #unregisterMBean(Object)
+     */
+    public void registerMBean(Object managedBean) {
+        Class<Object> managementInterface = getManagementInterface(managedBean);
+        InterfaceInfo interfaceInfo = InterfaceInfo.newIntance(managementInterface);
+        ObjectName objectName = interfaceInfo.getObjectName();
+        unregisterMBean(objectName);
+        registerMBean(managedBean, interfaceInfo, objectName);
+    }
+
+    private void registerMBean(Object managedBean, InterfaceInfo interfaceInfo, ObjectName objectName) {
+        try {
+            ManagedBeanWrapper standardMBean = new ManagedBeanWrapper(managedBean, interfaceInfo);
+            mBeanServer.registerMBean(standardMBean, objectName);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Unregister an object from JMX registry.
+     * <p>
+     *     The object must implement exactly one <em>direct</em> interface annotated with
+     *     {@link org.rhq.metrics.restServlet.management.MBean}.
+     * </p>
+     *
+     * @param managedBean the object to unregister
+     */
+    public void unregisterMBean(Object managedBean) {
+        Class<Object> managementInterface = getManagementInterface(managedBean);
+        InterfaceInfo interfaceInfo = InterfaceInfo.newIntance(managementInterface);
+        ObjectName objectName = interfaceInfo.getObjectName();
+        unregisterMBean(objectName);
+    }
+
+    private void unregisterMBean(ObjectName objectName) {
+        try {
+            if (mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Class<Object> getManagementInterface(Object managedBean) {
+        Set<Class<Object>> managementInterfaces = getManagementInterfaces(managedBean);
+        if (managementInterfaces.isEmpty()) {
+            throw new IllegalArgumentException("Managed bean has not direct management interface");
+        }
+        if (managementInterfaces.size() > 1) {
+            throw new IllegalArgumentException("Managed bean must have a single direct management interface");
+        }
+        return managementInterfaces.iterator().next();
+    }
+
+    private Set<Class<Object>> getManagementInterfaces(Object managedBean) {
+        Set<Class<Object>> managementInterfaces = new HashSet<>();
+        Class<?>[] beanDirectInterfaces = managedBean.getClass().getInterfaces();
+        for (Class<?> beanDirectInterface : beanDirectInterfaces) {
+            if (beanDirectInterface.isAnnotationPresent(MBean.class)) {
+                @SuppressWarnings("unchecked")
+                Class<Object> managementInterface = (Class<Object>) beanDirectInterface;
+                managementInterfaces.add(managementInterface);
+            }
+        }
+        return managementInterfaces;
+    }
+
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/ManagedBeanWrapper.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/ManagedBeanWrapper.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.util.function.Predicate.isEqual;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.NotCompliantMBeanException;
+import javax.management.StandardMBean;
+
+/**
+ * @author Thomas Segismont
+ */
+class ManagedBeanWrapper extends StandardMBean {
+    private final InterfaceInfo interfaceInfo;
+
+    ManagedBeanWrapper(Object managedBean, InterfaceInfo interfaceInfo) throws NotCompliantMBeanException {
+        super(managedBean, interfaceInfo.getInterfaceClass(), interfaceInfo.isMxBean());
+        this.interfaceInfo = interfaceInfo;
+    }
+
+    @Override
+    protected String getDescription(javax.management.MBeanInfo bean) {
+        String description = interfaceInfo.getDescription();
+        return description.trim().length() > 0 ?  description : super.getDescription(bean);
+    }
+
+    @Override
+    protected String getDescription(MBeanAttributeInfo op) {
+        Set<PropertyInfo> propertyInfos = interfaceInfo.getPropertyInfos();
+        PropertyInfo example = PropertyInfo.example(op.getType(), op.getName());
+        return propertyInfos.stream()
+                .filter(isEqual(example))
+                .findFirst()
+                .map(PropertyInfo::getDescription)
+                .map(description -> description.trim().length() > 0 ? description : super.getDescription(op))
+                .orElseThrow(() -> new RuntimeException("Unknown attribute"));
+    }
+
+    @Override
+    protected String getDescription(MBeanOperationInfo op) {
+        return getMethodInfo(op)
+                .map(MethodInfo::getDescription)
+                .map(description -> description.trim().length() > 0 ?  description : super.getDescription(op))
+                .orElseThrow(() -> new RuntimeException("Unknown operation"));
+    }
+
+    @Override
+    protected int getImpact(MBeanOperationInfo op) {
+        return getMethodInfo(op)
+                .map(MethodInfo::getImpact)
+                .orElseThrow(() -> new RuntimeException("Unknown operation"));
+    }
+
+    @Override
+    protected String getParameterName(MBeanOperationInfo op, MBeanParameterInfo param, int sequence) {
+        return getMethodInfo(op)
+                .map(MethodInfo::getParamNames)
+                .map(names -> names.get(sequence))
+                .map(name -> name.trim().length() > 0 ? name : super.getParameterName(op, param, sequence))
+                .orElseThrow(() -> new RuntimeException("Unkown operation"));
+    }
+
+    @Override
+    protected String getDescription(MBeanOperationInfo op, MBeanParameterInfo param, int sequence) {
+        return getMethodInfo(op)
+                .map(MethodInfo::getParamDescriptions)
+                .map(descriptions -> descriptions.get(sequence))
+                .map(desc -> desc.trim().length() > 0 ? desc : super.getDescription(op, param, sequence))
+                .orElseThrow(() -> new RuntimeException("Unkown operation"));
+    }
+
+    private Optional<MethodInfo> getMethodInfo(MBeanOperationInfo info) {
+        List<String> paramTypes = Arrays.stream(info.getSignature())
+                .map(MBeanParameterInfo::getType)
+                .collect(toList());
+        MethodInfo example = MethodInfo.example(info.getName(), paramTypes);
+        Set<MethodInfo> methodInfos = interfaceInfo.getMethodInfos();
+        return methodInfos
+                .stream()
+                .filter(isEqual(example))
+                .findFirst();
+    }
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MethodInfo.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/MethodInfo.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.util.stream.Collectors.toList;
+
+import java.beans.MethodDescriptor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.management.MBeanOperationInfo;
+
+/**
+ * @author Thomas Segismont
+ */
+class MethodInfo {
+    private final String name;
+    private final List<String> paramTypes;
+    private final String description;
+    private final int impact;
+    private final List<String> paramNames;
+    private final List<String> paramDescriptions;
+
+    private MethodInfo(String name, List<String> paramTypes, String description, int impact, List<String> paramNames,
+        List<String> paramDescriptions) {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(paramTypes);
+        Objects.requireNonNull(description);
+        Objects.requireNonNull(paramNames);
+        Objects.requireNonNull(paramDescriptions);
+        if (paramNames.size() != paramTypes.size() || paramNames.size() != paramDescriptions.size()) {
+            String msg = String.format("names (%s), types (%s) and descriptions (%s) don't have the same size",
+                paramNames, paramTypes, paramDescriptions);
+            throw new IllegalArgumentException(msg);
+        }
+        this.name = name;
+        this.paramTypes = paramTypes;
+        this.description = description;
+        this.impact = impact;
+        this.paramNames = paramNames;
+        this.paramDescriptions = paramDescriptions;
+    }
+
+    static MethodInfo example(String name, List<String> paramTypes) {
+        return new MethodInfo(name, paramTypes, "", 0, Collections.nCopies(paramTypes.size(), ""), Collections.nCopies(
+            paramTypes.size(), ""));
+    }
+
+    static Set<MethodInfo> from(MethodDescriptor[] methodDescriptors) {
+        Set<MethodInfo> infos = new HashSet<>();
+        if (methodDescriptors == null) {
+            return infos;
+        }
+        for (MethodDescriptor methodDescriptor : methodDescriptors) {
+            String name = methodDescriptor.getName();
+            Method method = methodDescriptor.getMethod();
+            Description description = method.getAnnotation(Description.class);
+            Impact impact = method.getAnnotation(Impact.class);
+            List<String> paramTypes = Arrays.stream(method.getParameterTypes())
+                    .map(Class::getName)
+                    .collect(toList());
+            List<String> paramNames = Arrays.stream(method.getParameters())
+                    .map(p -> {
+                        OperationParamName pName = p.getAnnotation(OperationParamName.class);
+                        return pName != null ? pName.value() : "";
+                    })
+                    .collect(toList());
+            List<String> paramDescriptions = Arrays.stream(method.getParameters()).map(p -> {
+                Description pDescription = p.getAnnotation(Description.class);
+                return pDescription != null ? pDescription.value() : "";
+            }).collect(toList());
+            MethodInfo info = new MethodInfo(name, paramTypes, description != null ? description.value() : "",
+                impact != null ? impact.value() : MBeanOperationInfo.UNKNOWN, paramNames, paramDescriptions);
+            infos.add(info);
+        }
+        return infos;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getParamTypes() {
+        return paramTypes;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getImpact() {
+        return impact;
+    }
+
+    public List<String> getParamNames() {
+        return paramNames;
+    }
+
+    public List<String> getParamDescriptions() {
+        return paramDescriptions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MethodInfo that = (MethodInfo) o;
+        return name.equals(that.name) && paramTypes.equals(that.paramTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name.hashCode();
+        result = 31 * result + paramTypes.hashCode();
+        return result;
+    }
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/OperationParamName.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/OperationParamName.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Provides a meaningful name for an operation parameter in a management interface (JMX uses meaningless names by
+ * default).
+ *
+ * @author Thomas Segismont
+ * @see org.rhq.metrics.restServlet.management.MBean
+ */
+@Retention(RUNTIME)
+@Target({ PARAMETER })
+@Documented
+public @interface OperationParamName {
+    /**
+     * @return the name of a JMX operation parameter
+     */
+    String value();
+}

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/PropertyInfo.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/management/PropertyInfo.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static java.lang.Character.isLowerCase;
+import static java.lang.Character.toUpperCase;
+
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Thomas Segismont
+ */
+class PropertyInfo {
+    private final String type;
+    private final String name;
+    private final String description;
+
+    private PropertyInfo(String type, String name, String description) {
+        Objects.requireNonNull(type);
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(description);
+        this.type = type;
+        this.name = name;
+        this.description = description;
+    }
+
+    static PropertyInfo example(String type, String name) {
+        return new PropertyInfo(type, name, "");
+    }
+
+    static Set<PropertyInfo> from(PropertyDescriptor[] propertyDescriptors) {
+        Set<PropertyInfo> infos = new HashSet<>();
+        if (propertyDescriptors == null) {
+            return infos;
+        }
+        for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
+            PropertyInfo info = from(propertyDescriptor);
+            infos.add(info);
+        }
+        return infos;
+    }
+
+    private static PropertyInfo from(PropertyDescriptor propertyDescriptor) {
+        Method method = propertyDescriptor.getReadMethod();
+        if (method == null) {
+            method = propertyDescriptor.getWriteMethod();
+        }
+        Description description = method.getAnnotation(Description.class);
+        String type = propertyDescriptor.getPropertyType().getName();
+        String name = propertyDescriptor.getName();
+        if (isLowerCase(name.charAt(0))) {
+            // JMX property names must start with an uppercase letter
+            name = toUpperCase(name.charAt(0)) + name.substring(1);
+        }
+        String descriptionText = description != null ? description.value() : "";
+        return new PropertyInfo(type, name, descriptionText);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        PropertyInfo that = (PropertyInfo) o;
+        return name.equals(that.name) && type.equals(that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = type.hashCode();
+        result = 31 * result + name.hashCode();
+        return result;
+    }
+}

--- a/rest-servlet/src/main/resources/META-INF/metrics.conf
+++ b/rest-servlet/src/main/resources/META-INF/metrics.conf
@@ -1,0 +1,2 @@
+# Internal configuration file, used to provide default values
+rhq-metrics.backend=mem

--- a/rest-servlet/src/test/java/org/rhq/metrics/restServlet/config/ConfigurableProducerTest.java
+++ b/rest-servlet/src/test/java/org/rhq/metrics/restServlet/config/ConfigurableProducerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Properties;
+
+import javax.enterprise.inject.spi.Annotated;
+import javax.enterprise.inject.spi.InjectionPoint;
+
+import com.google.common.io.Resources;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import org.rhq.metrics.restServlet.management.MBeanRegistrar;
+
+/**
+ * @author Thomas Segismont
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ConfigurableProducerTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Mock
+    private MBeanRegistrar mBeanRegistrar;
+    @Mock
+    private InjectionPoint injectionPoint;
+
+    private ConfigurableProducer configurableProducer = new ConfigurableProducer();
+
+    @Before
+    public void before() throws IOException {
+        configurableProducer.mBeanRegistrar = mBeanRegistrar;
+
+        Annotated annotated = mock(Annotated.class);
+        ConfigurationProperty configurationProperty = mock(ConfigurationProperty.class);
+        when(configurationProperty.value()).thenReturn(ConfigurationKey.BACKEND);
+        when(annotated.getAnnotation(eq(ConfigurationProperty.class))).thenReturn(configurationProperty);
+        injectionPoint = mock(InjectionPoint.class);
+        when(injectionPoint.getAnnotated()).thenReturn(annotated);
+    }
+
+    @After
+    public void after() {
+        System.clearProperty(ConfigurableProducer.METRICS_CONF);
+        System.clearProperty(ConfigurationKey.BACKEND.getExternalForm());
+    }
+
+    @Test
+    public void shouldFetchDefaultValue() throws Exception {
+        // Create an empty config file in case the user running tests has a config file in <user.home>
+        Properties emptyProperties = new Properties();
+        File configFile = tempFolder.newFile();
+        emptyProperties.store(new FileOutputStream(configFile), null);
+        System.setProperty(ConfigurableProducer.METRICS_CONF, configFile.getAbsolutePath());
+
+        configurableProducer.init();
+        String value = configurableProducer.getConfigurationPropertyAsString(injectionPoint);
+
+        Properties properties = new Properties();
+        URL resource = Resources.getResource("META-INF/metrics.conf");
+        properties.load(Resources.asByteSource(resource).openStream());
+
+        assertThat(value).isNotNull().isEqualTo(properties.getProperty(ConfigurationKey.BACKEND.getExternalForm()));
+    }
+
+    @Test
+    public void shouldFetchValueFromConfigFile() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(ConfigurationKey.BACKEND.getExternalForm(), "marseille");
+        File configFile = tempFolder.newFile();
+        properties.store(new FileOutputStream(configFile), null);
+        System.setProperty(ConfigurableProducer.METRICS_CONF, configFile.getAbsolutePath());
+
+        configurableProducer.init();
+        String value = configurableProducer.getConfigurationPropertyAsString(injectionPoint);
+
+        assertThat(value).isNotNull().isEqualTo("marseille");
+    }
+
+    @Test
+    public void shouldFetchValueFromSystemProperty() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty(ConfigurationKey.BACKEND.getExternalForm(), "marseille");
+        File configFile = tempFolder.newFile();
+        properties.store(new FileOutputStream(configFile), null);
+        System.setProperty(ConfigurableProducer.METRICS_CONF, configFile.getAbsolutePath());
+
+        System.setProperty(ConfigurationKey.BACKEND.getExternalForm(), "mare nostrum");
+
+        configurableProducer.init();
+        String value = configurableProducer.getConfigurationPropertyAsString(injectionPoint);
+
+        assertThat(value).isNotNull().isEqualTo("mare nostrum");
+    }
+
+    @Test
+    public void shouldThrowsIllegalArgumentExceptionIfAnnotationIsMissing() throws Exception {
+        // Override default: simulate a missing config property annotation
+        Annotated annotated = mock(Annotated.class);
+        when(annotated.getAnnotation(eq(ConfigurationProperty.class))).thenReturn(null);
+        InjectionPoint injectionPoint = mock(InjectionPoint.class);
+        when(injectionPoint.getAnnotated()).thenReturn(annotated);
+
+        try {
+            configurableProducer.getConfigurationPropertyAsString(injectionPoint);
+            fail("Expected " + IllegalArgumentException.class.getSimpleName());
+        } catch (Exception e) {
+            String message = "Any field or parameter annotated with @Configurable "
+                + "must also be annotated with @ConfigurationProperty";
+            assertThat(e).isInstanceOf(IllegalArgumentException.class).hasMessage(message);
+        }
+    }
+}

--- a/rest-servlet/src/test/java/org/rhq/metrics/restServlet/management/MBeanRegistrarTest.java
+++ b/rest-servlet/src/test/java/org/rhq/metrics/restServlet/management/MBeanRegistrarTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.rhq.metrics.restServlet.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.MBeanParameterInfo;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Thomas Segismont
+ */
+public class MBeanRegistrarTest {
+
+    private MBeanRegistrar mBeanRegistrar;
+    private Object sample;
+    private MBeanServer mBeanServer;
+
+    @Before
+    public void before() {
+        mBeanRegistrar = new MBeanRegistrar();
+        mBeanRegistrar.init();
+        mBeanServer = mBeanRegistrar.mBeanServer;
+        sample = new ManageableSample();
+    }
+
+    @Test
+    public void testRegisterMBean() throws Exception {
+        mBeanRegistrar.registerMBean(sample);
+        MBeanInfo mBean = mBeanServer.getMBeanInfo(new ObjectName("com.marseille:mare=nostrum"));
+        assertThat(mBean).isNotNull();
+        assertThat(mBean.getDescription()).isNotNull().isEqualTo("SampleManagementDescription");
+
+        MBeanAttributeInfo[] attributes = mBean.getAttributes();
+        assertThat(attributes).isNotNull().hasSize(2);
+        for (MBeanAttributeInfo attribute : attributes) {
+            switch (attribute.getName()) {
+            case "ReadWriteAttribute":
+                assertThat(attribute.getDescription()).isNotNull().isEqualTo("Description from RW getter method");
+                break;
+            case "WriteOnlyAttribute":
+                assertThat(attribute.getDescription()).isNotNull().isEqualTo("Description from W setter method");
+                break;
+            default:
+                fail("Unexpected attribute '" + attribute.getName() + "'");
+            }
+        }
+
+        MBeanOperationInfo[] operations = mBean.getOperations();
+        assertThat(operations).isNotNull().hasSize(2);
+        for (MBeanOperationInfo operation : operations) {
+            switch (operation.getName()) {
+            case "info":
+                assertThat(operation.getDescription()).isNotNull().isEqualTo("Description info");
+                assertThat(operation.getImpact()).isEqualTo(MBeanOperationInfo.INFO);
+                MBeanParameterInfo[] parameters = operation.getSignature();
+                assertThat(parameters).isNotNull().hasSize(1);
+                MBeanParameterInfo parameter = parameters[0];
+                assertThat(parameter.getName()).isNotNull().isEqualTo("marseille");
+                assertThat(parameter.getDescription()).isNotNull().isEqualTo("Description param");
+                break;
+            case "unknown":
+                assertThat(operation.getDescription()).isNotNull().isEqualTo("Description unknown");
+                assertThat(operation.getImpact()).isEqualTo(MBeanOperationInfo.UNKNOWN);
+                break;
+            default:
+                fail("Unexpected operation '" + operation.getName() + "'");
+            }
+        }
+    }
+
+    @After
+    public void after() {
+        mBeanRegistrar.unregisterMBean(sample);
+    }
+
+    @MBean(domain = "com.marseille", keyProperties = @KeyProperty(key = "mare", value = "nostrum"))
+    @Description("SampleManagementDescription")
+    public interface SampleManagement {
+        @Description("Description from RW getter method")
+        int[] getReadWriteAttribute();
+
+        @Description("Description from RW setter method")
+        void setReadWriteAttribute(int[] value);
+
+        @Description("Description from W setter method")
+        void setWriteOnlyAttribute(String value);
+
+        @Description("Description info")
+        @Impact(MBeanOperationInfo.INFO)
+        void info(@OperationParamName("marseille") @Description("Description param") String param);
+
+        @Description("Description unknown")
+        // Unspecified impact
+        int unknown(String param);
+    }
+
+    private class ManageableSample implements SampleManagement {
+        @Override
+        public int[] getReadWriteAttribute() {
+            return new int[0];
+        }
+
+        @Override
+        public void setReadWriteAttribute(int[] value) {
+        }
+
+        @Override
+        public void setWriteOnlyAttribute(String value) {
+        }
+
+        @Override
+        public void info(String param) {
+        }
+
+        @Override
+        public int unknown(String param) {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
This pull requests introduces JMX support (see commit 26da171) and configuration through dependency injection (see commit  969cf9b)

Here's an example of JMX support:
```java
@MBean(keyProperties = @KeyProperty(key = "type", value = "Configuration"))
@Description("Configuration management")
@MXBean
public interface ConfigurationManagement {
    @Description("Lists the configuration property keys. Some properties may be missing if they were not loaded yet.")
    String[] getConfigurationPropertyKeys();

    @Impact(MBeanOperationInfo.INFO)
    @Description("Get the value of a configuration property")
    String getConfigurationProperty(
        @Description("External form of the configuration property key") @OperationParamName("key") String key);

    @Impact(MBeanOperationInfo.ACTION)
    @Description("Set the value of a configuration property")
    void updateConfigurationProperty(@OperationParamName("key") String key, @OperationParamName("value") String value);
}
```

And of configuration:
```java
    @Inject
    @Configurable
    @ConfigurationProperty(BACKEND)
    private String backend;
```

I tested the new features manually and I'm working on some automated tests.

Any comments?