### PR TITLE
Executors usage cleanup

### DIFF
--- a/rest-servlet/pom.xml
+++ b/rest-servlet/pom.xml
@@ -80,11 +80,6 @@
       <artifactId>cdi-api</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
-      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
-      <scope>provided</scope>
-    </dependency>
 
     <!-- documentation -->
     <dependency>

--- a/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/InfluxSeriesHandler.java
+++ b/rest-servlet/src/main/java/org/rhq/metrics/restServlet/influx/InfluxSeriesHandler.java
@@ -32,8 +32,6 @@ import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import javax.annotation.Resource;
-import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import javax.ws.rs.Consumes;
@@ -113,9 +111,6 @@ public class InfluxSeriesHandler {
     QueryValidator queryValidator;
     @Inject
     ToIntervalTranslator toIntervalTranslator;
-
-    @Resource
-    ManagedExecutorService executor;
 
     @POST
     @Consumes(APPLICATION_JSON)
@@ -218,7 +213,7 @@ public class InfluxSeriesHandler {
             public void onFailure(Throwable t) {
                 asyncResponse.resume(t);
             }
-        }, executor);
+        });
     }
 
     private void select(AsyncResponse asyncResponse, String tenantId, SelectQueryContext selectQueryContext) {
@@ -259,7 +254,7 @@ public class InfluxSeriesHandler {
                     }
                     return metricsService.findData(new NumericMetric(tenantId, new MetricId(metric)),
                         timeInterval.getStartMillis(), timeInterval.getEndMillis());
-                }, executor);
+                });
         ListenableFuture<List<InfluxObject>> influxObjectTranslatorFuture = Futures.transform(loadMetricsFuture,
                 (List<NumericData> metrics) -> {
                     if (metrics == null) {
@@ -305,7 +300,7 @@ public class InfluxSeriesHandler {
                     objects.add(builder.createInfluxObject());
 
                     return objects;
-                }, executor);
+                });
         Futures.addCallback(influxObjectTranslatorFuture, new FutureCallback<List<InfluxObject>>() {
             @Override
             public void onSuccess(List<InfluxObject> objects) {
@@ -322,7 +317,7 @@ public class InfluxSeriesHandler {
             public void onFailure(Throwable t) {
                 asyncResponse.resume(t);
             }
-        }, executor);
+        });
     }
 
     private boolean shouldApplyMapping(SelectQueryDefinitions queryDefinitions) {


### PR DESCRIPTION
* Removed dependency on EE7 managed executors API
* InfluxSeriesHandler: execute all transformations in the same thread (metricsTask thread)
* MetricsServiceCassandra: add missing "metricsTasks" specifications, remove where not needed