### PR TITLE
ptrans PID file

### DIFF
--- a/clients/ptranslator/pom.xml
+++ b/clients/ptranslator/pom.xml
@@ -71,6 +71,11 @@
       <artifactId>netty-collectd</artifactId>
       <version>0.1</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.jnr</groupId>
+      <artifactId>jnr-posix</artifactId>
+      <version>3.0.9</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/OptionsFactory.java
+++ b/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/OptionsFactory.java
@@ -16,6 +16,7 @@
  */
 package org.rhq.metrics.clients.ptrans;
 
+import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
 /**
@@ -28,6 +29,8 @@ class OptionsFactory {
     static final String HELP_LONGOPT = "help";
     static final String CONFIG_FILE_OPT = "c";
     static final String CONFIG_FILE_LONGOPT = "config-file";
+    static final String PID_FILE_OPT = "p";
+    static final String PID_FILE_LONGOPT = "pid-file";
 
     /**
      * @param withRequiredFlags true if required options should be marked as such
@@ -36,8 +39,11 @@ class OptionsFactory {
     Options getCommandOptions(boolean withRequiredFlags) {
         Options options = new Options();
         options.addOption(HELP_OPT, HELP_LONGOPT, false, "Print usage and exit.");
-        options.addOption(CONFIG_FILE_OPT, CONFIG_FILE_LONGOPT, true, "Set the path to the configuration file.");
-        options.getOption(CONFIG_FILE_OPT).setRequired(withRequiredFlags);
+        Option configFileOption = new Option(CONFIG_FILE_OPT, CONFIG_FILE_LONGOPT, true,
+            "Set the path to the configuration file.");
+        configFileOption.setRequired(withRequiredFlags);
+        options.addOption(configFileOption);
+        options.addOption(PID_FILE_OPT, PID_FILE_LONGOPT, true, "Set the path to the PID file.");
         return options;
     }
 }

--- a/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/PidFile.java
+++ b/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/PidFile.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2014-2015 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.rhq.metrics.clients.ptrans;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * @author Thomas Segismont
+ */
+class PidFile {
+
+    private final File file;
+    private FileChannel channel;
+    private FileLock fileLock;
+
+    PidFile(File file) {
+        this.file = file;
+    }
+
+    boolean tryLock(int pid) {
+        try {
+            channel = new RandomAccessFile(file, "rw").getChannel();
+        } catch (FileNotFoundException e) {
+            System.err.printf("Unable to open PID file %s for writing.%n", file.getAbsolutePath());
+            return false;
+        }
+        try {
+            fileLock = channel.tryLock();
+        } catch (IOException e) {
+            System.err.printf("Unable to lock PID file %s.%n", file.getAbsolutePath());
+            return false;
+        }
+        if (fileLock == null) {
+            System.err.printf("Unable to lock PID file %s, another instance is probably running.%n",
+                file.getAbsolutePath());
+            return false;
+        }
+        try {
+            channel.truncate(0);
+        } catch (IOException e) {
+            System.err.printf("Unable to truncate PID file %s.%n", file.getAbsolutePath());
+            return false;
+        }
+        byte[] bytes = String.format("%d%n", pid).getBytes(StandardCharsets.US_ASCII);
+        try {
+            channel.write(ByteBuffer.wrap(bytes));
+        } catch (IOException e) {
+            System.err.printf("Unable to write to PID file %s.%n", file.getAbsolutePath());
+            return false;
+        }
+        return true;
+    }
+
+    void release() {
+        if (fileLock != null) {
+            try {
+                fileLock.release();
+            } catch (IOException ignored) {
+            }
+        }
+        if (channel != null) {
+            try {
+                channel.close();
+            } catch (IOException ignored) {
+            }
+        }
+    }
+
+}

--- a/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/PidFile.java
+++ b/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/PidFile.java
@@ -44,8 +44,12 @@ class PidFile {
     }
 
     /**
-     * Try to acquire a write lock on the PID file and, on success, write the {@code pid} to it. On failure to open the
-     * file, acquire the lock or write to the file, an error message will be printed to {@link java.lang.System#err}.
+     * Try to acquire a write lock on the PID file and, on success, write the {@code pid} to it and mark it for deletion
+     * on exit.
+     * <p>
+     * On failure to open the file, acquire the lock or write to the file, an error message will be printed to {@link
+     * java.lang.System#err}.
+     * <p>
      * The caller must call {@link #release()} before the JVM stops, regardless of the the result of this method.
      *
      * @param pid the process id to write
@@ -83,6 +87,7 @@ class PidFile {
             System.err.printf("Unable to write to PID file %s.%n", file.getAbsolutePath());
             return false;
         }
+        file.deleteOnExit();
         return true;
     }
 

--- a/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/PidFile.java
+++ b/clients/ptranslator/src/main/java/org/rhq/metrics/clients/ptrans/PidFile.java
@@ -26,6 +26,8 @@ import java.nio.channels.FileLock;
 import java.nio.charset.StandardCharsets;
 
 /**
+ * Helper class to manage a PID file.
+ *
  * @author Thomas Segismont
  */
 class PidFile {
@@ -34,10 +36,22 @@ class PidFile {
     private FileChannel channel;
     private FileLock fileLock;
 
+    /**
+     * @param file PID file reference
+     */
     PidFile(File file) {
         this.file = file;
     }
 
+    /**
+     * Try to acquire a write lock on the PID file and, on success, write the {@code pid} to it. On failure to open the
+     * file, acquire the lock or write to the file, an error message will be printed to {@link java.lang.System#err}.
+     * The caller must call {@link #release()} before the JVM stops, regardless of the the result of this method.
+     *
+     * @param pid the process id to write
+     *
+     * @return true if the lock was acquired and the {@code pid} written to the PID file, false otherwise
+     */
     boolean tryLock(int pid) {
         try {
             channel = new RandomAccessFile(file, "rw").getChannel();
@@ -72,6 +86,9 @@ class PidFile {
         return true;
     }
 
+    /**
+     * Release resources used to managed the PID file.
+     */
     void release() {
         if (fileLock != null) {
             try {


### PR DESCRIPTION
Added a "-p" to set the path to the PID file

ptrans will try to acquire a write lock on the PID file

Java has no built-in support for self PID so the PID is provided by
JNR (the library built by the JRuby team).