### PR TITLE
Upgrade ANTLR to avoid suspicious warning on Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <jackson.version>2.3.2</jackson.version>
     <trove4j.version>3.0.3</trove4j.version>
     <google.guava.version>16.0.1</google.guava.version>
-    <antlr.version>4.3</antlr.version>
+    <antlr.version>4.5</antlr.version>
 
     <version.wildfly>8.2.0.Final</version.wildfly>
     <findbugs.version>3.0.0</findbugs.version>


### PR DESCRIPTION
Upgrade ANTLR to avoid suspicious warning on Java 8

"Supported source version 'RELEASE_6' from annotation processor 'org.antlr.v4.runtime.misc.NullUsageProcessor' less than -source '1.8'"

See https://github.com/antlr/antlr4/issues/487